### PR TITLE
feat: Add the ability to import a game via FEN

### DIFF
--- a/.config/locale/en.yml
+++ b/.config/locale/en.yml
@@ -255,11 +255,12 @@ en:
         wait: "Please wait... "
       load:
         f1: |
-          * Start a new game or load game from profile
+          * Start a new game or load game from profile/FEN
           *   • [1] New Game
           *   • [2] Load Game
+          *   • [3] Import Game via FEN data
         f1a: "Please select a load mode: "
-        f1a_err: "Invalid input, please choose between 1 or 2"
+        f1a_err: "Invalid input, please choose between 1 to 3: "
         f2a: "Please enter a number to indicate the session you wish to load:"
         f2b: "Select a game session to resume:"
         f2b_err: "Invalid input, please choose between 1 to %{max}"
@@ -273,6 +274,7 @@ en:
         f1a_err: "Invalid input, please choose between 1 or 2"
         f2: "Please name Player %{count} (Default: %{name})"
         f2a: "Name has been updated to '%{name}'."
+        f3: "Provide a valid FEN below, invalid FEN will cancel the operation and a new game will be setup instead."
         err: "Sessions not found, entering new game creation mode..."
       order:
         f1: |

--- a/lib/console_game/chess/utilities/fen_import.rb
+++ b/lib/console_game/chess/utilities/fen_import.rb
@@ -16,6 +16,9 @@ module ConsoleGame
       # Pieces limits
       LIMITS = { "k" => 1, "q" => 9, "b" => 10, "n" => 10, "r" => 10, "p" => 8 }.freeze
 
+      # Basic parse pattern
+      FEN_PATTERN = /\A[kqrbnp1-8]+\z/i
+
       # FEN Raw data parser (FEN import)
       # @return [Hash<Hash>] FEN data hash for internal use
       def self.parse_fen(...) = new(...).parse_fen
@@ -116,7 +119,7 @@ module ConsoleGame
       # Pattern matching checks for FEN string
       # @param rank [String]
       # @return [Boolean]
-      def valid_characters?(rank, _row) = rank.match?(/\A[kqrbnp1-8]+\z/i)
+      def valid_characters?(rank, _row) = rank.match?(FEN_PATTERN)
 
       # Acceptance checks for the first row and last row (Lazy evaluation)
       # Main criteria: No black pawn in rank 8 and no white pawn in rank 1

--- a/spec/console_game/chess/game_spec.rb
+++ b/spec/console_game/chess/game_spec.rb
@@ -29,6 +29,20 @@ describe ConsoleGame::Chess::Game do
       end
     end
 
+    context "when user wishes to import a game via FEN string" do
+      before do
+        allow($stdout).to receive(:puts)
+        chess_manager.instance_variable_set(:@sessions, test_sessions)
+        allow(game_manager).to receive(:save_user_profile)
+        allow(game_manager).to receive(:exit_arcade).and_raise(SystemExit)
+      end
+
+      it "opens level and exit successfully" do
+        allow(Readline).to receive(:readline).and_return("", "", "", "3", "1", "", "", "1", "rnbqkbnr/ppp3pp/4pp2/3p4/5B2/2PP4/PP2PPPP/RN1QKBNR w KQkq - 0 1", "d4d5", "--exit")
+        expect { chess_manager.start }.to raise_error(SystemExit)
+      end
+    end
+
     context "when user wishes to create a new game and load another session mid game" do
       before do
         allow($stdout).to receive(:puts)


### PR DESCRIPTION
### Description

This pull request introduces a new feature to import chess games using FEN (Forsyth-Edwards Notation) strings, along with improvements to the game's setup flow and validation logic.
A new game mode selection for chess aka mode `[3] - Import game via FEN`. This option allow user to paste a valid FEN data string and a new game is created based on the data parsed from `FenImport`.

---
